### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,85 @@
+# Copyright 2022 Adam Chalkley
+#
+# https://github.com/atc0005/check-process
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+# https://help.github.com/en/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Enable version updates for Go modules
+  - package-ecosystem: "gomod"
+
+    # Look for a `go.mod` file in the `root` directory
+    directory: "/"
+
+    # Default is a maximum of five pull requests for version updates
+    open-pull-requests-limit: 10
+
+    target-branch: "master"
+
+    # Daily update checks; default version checks are performed at 05:00 UTC
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+
+    # Assign everything to me by default
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+
+    allow:
+      # Allow both direct and indirect updates for all packages
+      - dependency-type: "all"
+
+    commit-message:
+      # Prefix all commit messages with "go.mod"
+      prefix: "go.mod"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "ghaw"
+
+  # Monitor Go updates to serve as a reminder to generate fresh binaries
+  - package-ecosystem: docker
+    directory: "/dependabot/docker/go"
+    open-pull-requests-limit: 10
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+      time: "02:00"
+      timezone: "America/Chicago"
+    assignees:
+      - "atc0005"
+    labels:
+      - "dependencies"
+      - "CI"
+    allow:
+      - dependency-type: "all"
+    commit-message:
+      prefix: "canary"
+    ignore:
+      - dependency-name: "golang"
+        versions:
+          # Ignore updates from series associated with the latest "stable"
+          # Go release and no longer supported Go versions.
+          - ">= 1.20"
+          - "< 1.19"

--- a/dependabot/docker/go/Dockerfile
+++ b/dependabot/docker/go/Dockerfile
@@ -1,0 +1,18 @@
+# Copyright 2022 Adam Chalkley
+#
+# https://github.com/atc0005/check-process
+#
+# Licensed under the MIT License. See LICENSE file in the project root for
+# full license information.
+
+
+# Purpose:
+#
+# "Canary" Dockerfile for Go updates, monitored by Dependabot.
+#
+# After Dependabot provides a (valid) Pull Request to update this file, I
+# should begin the process of preparing a new project release (including
+# binaries) to reflect that version of Go.
+
+# https://hub.docker.com/_/golang
+FROM golang:1.19.2


### PR DESCRIPTION
- add Dependabot config file with standard project settings
  - monitor Go dependencies
  - monitor GitHub Actions dependencies
  - monitor Docker "Canary" Dockerfile
- add Docker "Canary" Dockerfile
    - used to indicate when a new Go toolchain update is available

fixes GH-7