### PR TITLE
Fix Evaluated process count in one-line summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ been exceeded.
 
 ```console
 $ ./check_process
-CRITICAL: Problematic processes found (D (disk sleep) [2], R (running) [7], S (sleeping) [368], evaluated [377])
+CRITICAL: 2 problematic processes found (D (disk sleep) [2], R (running) [7], S (sleeping) [368], evaluated [377])
 
 Process Summary:
 

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -30,13 +30,14 @@ func CheckProcessOneLineSummary(processes process.Processes) string {
 		summaryList := processes.SummaryList()
 		summaryList = append(summaryList, fmt.Sprintf(
 			"evaluated [%d]",
-			probProcs.Count(),
+			processes.Count(),
 		))
 		procsSummary := strings.Join(summaryList, ", ")
 
 		summary = fmt.Sprintf(
-			"%s: Problematic processes found (%s)",
+			"%s: %d problematic processes found (%s)",
 			processes.ServiceState().Label,
+			probProcs.Count(),
 			procsSummary,
 		)
 


### PR DESCRIPTION
Use the count for the entire set as the Evaluated count, list the
problematic processes first for the quick "how many are a problem"
coverage intended by the summary (the test of the info is just
additional context).
 