### PR TITLE
Minor refactoring to resolve gocognit warnings

### DIFF
--- a/cmd/check_process/main.go
+++ b/cmd/check_process/main.go
@@ -67,20 +67,7 @@ func main() {
 	}
 
 	// Collect last minute details just before ending plugin execution.
-	defer func(exitState *nagios.ExitState, start time.Time, logger zerolog.Logger) {
-
-		// Record plugin runtime, emit this metric regardless of exit
-		// point/cause.
-		runtimeMetric := nagios.PerformanceData{
-			Label: "time",
-			Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
-		}
-		if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
-			logger.Error().
-				Err(err).
-				Msg("failed to add time (runtime) performance data metric")
-		}
-	}(&nagiosExitState, pluginStart, cfg.Log)
+	defer appendPerfData(&nagiosExitState, pluginStart, cfg.Log)
 
 	if cfg.EmitBranding {
 		// If enabled, show application details at end of notification

--- a/cmd/check_process/perfdata.go
+++ b/cmd/check_process/perfdata.go
@@ -9,10 +9,27 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/atc0005/check-process/internal/process"
 	"github.com/atc0005/go-nagios"
+	"github.com/rs/zerolog"
 )
+
+func appendPerfData(exitState *nagios.ExitState, start time.Time, logger zerolog.Logger) {
+	// Record plugin runtime, emit this metric regardless of exit
+	// point/cause.
+	runtimeMetric := nagios.PerformanceData{
+		Label: "time",
+		Value: fmt.Sprintf("%dms", time.Since(start).Milliseconds()),
+	}
+	if err := exitState.AddPerfData(false, runtimeMetric); err != nil {
+		logger.Error().
+			Err(err).
+			Msg("failed to add time (runtime) performance data metric")
+	}
+
+}
 
 // getPerfData gathers performance data metrics that we wish to report.
 func getPerfData(processes process.Processes) []nagios.PerformanceData {


### PR DESCRIPTION
Spin off separate helper functions to reduce complexity of logic in two places to resolve "cognitive complexity" linter warnings.