### PR TITLE
Exclude PID of our tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ writing Linux is the only supported OS
 - Optional, leveled logging using `rs/zerolog` package
   - JSON-format output (to `stderr`)
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
-    default), `debug` or `trace`.
+    default), `debug` or `trace`
+
+NOTE: This tool ignores its own process entry when reporting running processes.
 
 ### `lsps` CLI tool
 
@@ -92,7 +94,9 @@ Small CLI tool to list processes with known problematic processes.
 - Optional, leveled logging using `rs/zerolog` package
   - JSON-format output (to `stderr`)
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
-    default), `debug` or `trace`.
+    default), `debug` or `trace`
+
+NOTE: This tool ignores its own process entry when reporting running processes.
 
 ## Changelog
 

--- a/cmd/check_process/main.go
+++ b/cmd/check_process/main.go
@@ -116,6 +116,16 @@ func main() {
 		Int("processes", len(processes)).
 		Msg("Collected info on processes")
 
+	logger.Debug().
+		Str("my_name", os.Args[0]).
+		Int("my_process_id", os.Getpid()).
+		Msg("Excluding process of current tool")
+	processes = processes.ExcludeMyPID()
+
+	logger.Debug().
+		Int("processes", len(processes)).
+		Msg("Excluded process of current tool")
+
 	switch {
 	case !processes.IsOKState():
 

--- a/cmd/lsps/list.go
+++ b/cmd/lsps/list.go
@@ -42,7 +42,7 @@ func listProcesses(w io.Writer, processes process.Processes) {
 // The summary is written to the specified io.Writer.
 func listOtherProcesses(w io.Writer, evaluated process.Processes, all process.Processes, includeDetails bool) {
 
-	remaining := all.Exclude(evaluated)
+	remaining := all.Exclude(evaluated...)
 
 	if len(remaining) == 0 {
 		return

--- a/cmd/lsps/main.go
+++ b/cmd/lsps/main.go
@@ -70,6 +70,16 @@ func main() {
 		Int("processes", len(processes)).
 		Msg("Collected info on processes")
 
+	logger.Debug().
+		Str("my_name", os.Args[0]).
+		Int("my_process_id", os.Getpid()).
+		Msg("Excluding process of current tool")
+	processes = processes.ExcludeMyPID()
+
+	logger.Debug().
+		Int("processes", len(processes)).
+		Msg("Excluded process of current tool")
+
 	fmt.Println("Problematic processes:")
 
 	probProcs := processes.States(process.KnownProblemProcessStates())

--- a/internal/process/processes.go
+++ b/internal/process/processes.go
@@ -9,6 +9,7 @@ package process
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -37,7 +38,7 @@ func (ps Processes) ParentProcess(p Process) (Process, error) {
 // Exclude returns Process values from the collection which are not in the
 // specified set. If the specified set is empty all Process values in the
 // collection are returned. If the
-func (ps Processes) Exclude(exclude Processes) Processes {
+func (ps Processes) Exclude(exclude ...Process) Processes {
 
 	// Build index of ID values the set we are to exclude.
 	excludePids := make(map[int]struct{}, len(exclude))
@@ -55,6 +56,35 @@ func (ps Processes) Exclude(exclude Processes) Processes {
 	for _, p := range ps {
 		_, excluded := excludePids[p.Pid]
 		if !excluded {
+			remaining = append(remaining, p)
+		}
+	}
+
+	return remaining
+}
+
+// MyProcess returns the Process value from the collection which matches the
+// current process ID value of the tool executing this code. A zero value
+// Process is returned if a match is not found for the current process ID
+// value.
+func (ps Processes) MyProcess() Process {
+	myPID := os.Getpid()
+	for _, p := range ps {
+		if p.Pid == myPID {
+			return p
+		}
+	}
+
+	return Process{}
+}
+
+// ExcludeMyPID returns Process values from the collection which do not match
+// the current process ID value of the tool executing this code.
+func (ps Processes) ExcludeMyPID() Processes {
+	myPID := os.Getpid()
+	remaining := make(Processes, 0)
+	for _, p := range ps {
+		if p.Pid != myPID {
 			remaining = append(remaining, p)
 		}
 	}


### PR DESCRIPTION
- update (process.Processes).Exclude method to accept variadic arguments instead of an explicit slice
- add (process.Processes).MyProcess method to return the Process value for the current running tool's PID (e.g., lsps or check_process)
- add (process.Processes).ExcludeMyPID method to return the current collection of Process values excluding the Process value for the current PID
- update lsps and check_process tools to explicitly exclude the tool's PID from those reported

fixes GH-26