### PR TITLE
Use UNKNOWN state for perfdata add failures

### DIFF
--- a/cmd/check_process/main.go
+++ b/cmd/check_process/main.go
@@ -136,6 +136,15 @@ func main() {
 			logger.Error().
 				Err(err).
 				Msg("failed to add performance data")
+
+			// Surface the error in plugin output.
+			plugin.AddError(err)
+
+			plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
+			plugin.ServiceOutput = fmt.Sprintf(
+				"%s: Failed to process performance data metrics",
+				nagios.StateUNKNOWNLabel,
+			)
 		}
 
 		return


### PR DESCRIPTION
Abort with UNKNOWN state when failing to add/gather generated performance data.

refs GH-51