### PR TITLE
Use UNKNOWN state for evaluation failures

### DIFF
--- a/cmd/check_process/main.go
+++ b/cmd/check_process/main.go
@@ -73,10 +73,10 @@ func main() {
 		logger.Error().Err(err).Msg("Failed to evaluate process directories")
 
 		plugin.AddError(err)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to evaluate process directories",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 		)
 
 		return
@@ -92,10 +92,10 @@ func main() {
 		logger.Error().Err(err).Msg("Failed to obtain list of process values")
 
 		plugin.AddError(err)
-		plugin.ExitStatusCode = nagios.StateCRITICALExitCode
+		plugin.ExitStatusCode = nagios.StateUNKNOWNExitCode
 		plugin.ServiceOutput = fmt.Sprintf(
 			"%s: Failed to process proc status files",
-			nagios.StateCRITICALLabel,
+			nagios.StateUNKNOWNLabel,
 		)
 
 		return


### PR DESCRIPTION
## Changes

- failure to evaluate process directories
- failure to obtain list of process values

These changes are made to comply with Nagios Plugin Guideline recommendations.

## References

- fixes atc0005/check-process#51
- atc0005/todo#55
- https://nagios-plugins.org/doc/guidelines.html