### PR TITLE
Add missing branding flag support

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -17,11 +17,10 @@ const ExitCodeCatchall int = 1
 
 // Shared flag help text
 const (
-	versionFlagHelp      string = "Whether to display application version and then immediately exit application."
-	logLevelFlagHelp     string = "Sets log level."
-	brandingFlagHelp     string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
-	emitBrandingFlagHelp string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
-	helpFlagHelp         string = "Emit this help text"
+	versionFlagHelp  string = "Whether to display application version and then immediately exit application."
+	logLevelFlagHelp string = "Sets log level."
+	brandingFlagHelp string = "Toggles emission of branding details with plugin status details. This output is disabled by default."
+	helpFlagHelp     string = "Emit this help text"
 )
 
 const (

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -55,8 +55,11 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels()),
 	)
 
-	if appType.Inspector {
+	switch {
+	case appType.Inspector:
 		c.flagSet.BoolVar(&c.InspectorSettings.ShowAll, ShowAllProcessesFlagLong, defaultShowAllProcesses, showAllProcessesFlagHelp)
+	case appType.Plugin:
+		c.flagSet.BoolVar(&c.EmitBranding, BrandingFlag, defaultEmitBranding, brandingFlagHelp)
 	}
 
 	// Allow our function to override the default Help output.


### PR DESCRIPTION
- remove emitBrandingFlagHelp config package constant (unused)
- add missing branding flag

The check_process plugin checked whether the flag value was set to emit the branding output, but support for using the flag wasn't in place as intended.