### PR TITLE
Correct logging format listed in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ writing Linux is the only supported OS
     the service check result
 
 - Optional, leveled logging using `rs/zerolog` package
-  - JSON-format output (to `stderr`)
+  - [`logfmt`][logfmt] format output (to `stderr`)
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
     default), `debug` or `trace`
 
@@ -91,7 +91,7 @@ Small CLI tool to list processes with known problematic processes.
     the service check result
 
 - Optional, leveled logging using `rs/zerolog` package
-  - JSON-format output (to `stderr`)
+  - [`logfmt`][logfmt] format output (to `stderr`)
   - choice of `disabled`, `panic`, `fatal`, `error`, `warn`, `info` (the
     default), `debug` or `trace`
 
@@ -491,3 +491,5 @@ See the [LICENSE](LICENSE) file for details.
 [go-docs-install]: <https://golang.org/doc/install>  "Install Go"
 
 [go-supported-releases]: <https://go.dev/doc/devel/release#policy> "Go Release Policy"
+
+[logfmt]: <https://brandur.org/logfmt>


### PR DESCRIPTION
The logging output format was previously listed as `JSON`. Update this to correctly indicate that this project currently uses the `logfmt` format instead.

refs atc0005/todo#64
refs https://brandur.org/logfmt