### PR TITLE
Fix goconst linting errors

### DIFF
--- a/internal/config/constants.go
+++ b/internal/config/constants.go
@@ -27,6 +27,10 @@ const (
 	showAllProcessesFlagHelp string = "Toggles listing of all processes. WARNING: This may produce a LOT of output. Disabled by default."
 )
 
+// shorthandFlagSuffix is appended to short flag help text to emphasize that
+// the flag is a shorthand version of a longer flag.
+const shorthandFlagSuffix = " (shorthand)"
+
 // Flag names for consistent references. Exported so that they're available
 // from tests.
 const (

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -37,7 +37,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 	}
 
 	// shared flags
-	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+" (shorthand)")
+	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagShort, defaultHelp, helpFlagHelp+shorthandFlagSuffix)
 	c.flagSet.BoolVar(&c.ShowHelp, HelpFlagLong, defaultHelp, helpFlagHelp)
 
 	c.flagSet.BoolVar(&c.ShowVersion, VersionFlagLong, defaultDisplayVersionAndExit, versionFlagHelp)
@@ -46,7 +46,7 @@ func (c *Config) handleFlagsConfig(appType AppType) error {
 		&c.LoggingLevel,
 		LogLevelFlagShort,
 		defaultLogLevel,
-		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels())+" (shorthand)",
+		supportedValuesFlagHelpText(logLevelFlagHelp, supportedLogLevels())+shorthandFlagSuffix,
 	)
 	c.flagSet.StringVar(
 		&c.LoggingLevel,


### PR DESCRIPTION
Replace literal text with new `shorthandFlagSuffix` config constant.