### PR TITLE
Fix errcheck linting errors

### DIFF
--- a/cmd/lsps/list.go
+++ b/cmd/lsps/list.go
@@ -25,14 +25,14 @@ func listProcesses(w io.Writer, processes process.Processes) {
 			writeProcessInfoLine(w, p, processes, true)
 		}
 
-		fmt.Fprintf(w, "\nSummary:\n\n")
+		_, _ = fmt.Fprintf(w, "\nSummary:\n\n")
 		for _, item := range processes.SummaryList() {
-			fmt.Fprintf(w, "  - %s\n", item)
+			_, _ = fmt.Fprintf(w, "  - %s\n", item)
 		}
-		fmt.Fprintln(w)
+		_, _ = fmt.Fprintln(w)
 
 	default:
-		fmt.Fprintf(w, "\n  - None\n")
+		_, _ = fmt.Fprintf(w, "\n  - None\n")
 	}
 
 }
@@ -48,16 +48,16 @@ func listOtherProcesses(w io.Writer, evaluated process.Processes, all process.Pr
 		return
 	}
 
-	fmt.Fprintf(w, "\nSUMMARY:\n\n")
+	_, _ = fmt.Fprintf(w, "\nSUMMARY:\n\n")
 	for _, item := range remaining.SummaryList() {
-		fmt.Fprintf(w, "  - %s\n", item)
+		_, _ = fmt.Fprintf(w, "  - %s\n", item)
 	}
-	fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w)
 
 	if includeDetails {
 		fmt.Printf("\n%s\n\n", strings.Repeat("-", 50))
 
-		fmt.Fprintf(w, "\nDETAILS:\n")
+		_, _ = fmt.Fprintf(w, "\nDETAILS:\n")
 
 		// for _, p := range remaining {
 		// 	writeProcessInfoLine(w, p, remaining)
@@ -72,7 +72,7 @@ func listOtherProcesses(w io.Writer, evaluated process.Processes, all process.Pr
 
 		// Write out the state as a header, emit the processes for that state.
 		for state, ps := range stateIndex {
-			fmt.Fprintf(w, "\n%s\n", state)
+			_, _ = fmt.Fprintf(w, "\n%s\n", state)
 			for _, p := range ps {
 				writeProcessInfoLine(w, p, remaining, false)
 			}
@@ -96,7 +96,7 @@ func writeProcessInfoLine(w io.Writer, p process.Process, ps process.Processes, 
 	switch includeStateField {
 	case true:
 		lineTmpl := "  - Name: %10s [Parent: %v (%v), State: %v, Pid: %v, PPid: %v, VMSwap: %v, Threads: %v]\n"
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			lineTmpl,
 			p.Name,
@@ -110,7 +110,7 @@ func writeProcessInfoLine(w io.Writer, p process.Process, ps process.Processes, 
 		)
 	default:
 		lineTmpl := "  - Name: %10s [Parent: %v (%v), Pid: %v, PPid: %v, VMSwap: %v, Threads: %v]\n"
-		fmt.Fprintf(
+		_, _ = fmt.Fprintf(
 			w,
 			lineTmpl,
 			p.Name,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 	// Uninitialized flagset, provide stub usage information.
 	case flagSet == nil:
 		return func() {
-			fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
+			_, _ = fmt.Fprintln(w, "Failed to initialize configuration; nil FlagSet")
 		}
 
 	// Non-nil flagSet, proceed
@@ -141,8 +141,8 @@ func Usage(flagSet *flag.FlagSet, w io.Writer) func() {
 		flagSet.SetOutput(w)
 
 		return func() {
-			fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
-			fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+			_, _ = fmt.Fprintln(flag.CommandLine.Output(), "\n"+Version()+"\n")
+			_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
 			flagSet.PrintDefaults()
 		}
 	}
@@ -162,7 +162,7 @@ func (c *Config) Help() string {
 	// Handle nil configuration initialization.
 	case c == nil || c.flagSet == nil:
 		// Fallback message noting the issue.
-		fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
+		_, _ = fmt.Fprintln(&helpTxt, ErrConfigNotInitialized)
 
 	default:
 		// Emit expected help output to builder.

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -61,11 +61,11 @@ func CheckProcessOneLineSummary(processes process.Processes) string {
 // plugin report.
 func writeReportHeader(w io.Writer, processes process.Processes) {
 
-	fmt.Fprintf(w, "Process Summary:%[1]s%[1]s", nagios.CheckOutputEOL)
+	_, _ = fmt.Fprintf(w, "Process Summary:%[1]s%[1]s", nagios.CheckOutputEOL)
 	for _, item := range processes.SummaryList() {
-		fmt.Fprintf(w, "  - %s\n", item)
+		_, _ = fmt.Fprintf(w, "  - %s\n", item)
 	}
-	fmt.Fprintf(w, "%[1]s%[1]s", nagios.CheckOutputEOL)
+	_, _ = fmt.Fprintf(w, "%[1]s%[1]s", nagios.CheckOutputEOL)
 
 }
 
@@ -75,7 +75,7 @@ func writeReportProblemEntries(w io.Writer, processes process.Processes) {
 
 	probProcs := processes.States(process.KnownProblemProcessStates())
 
-	fmt.Fprintf(w, "%[1]sProblems:%[1]s", nagios.CheckOutputEOL)
+	_, _ = fmt.Fprintf(w, "%[1]sProblems:%[1]s", nagios.CheckOutputEOL)
 
 	switch {
 	case len(probProcs) > 0:
@@ -88,7 +88,7 @@ func writeReportProblemEntries(w io.Writer, processes process.Processes) {
 				ppID = -1
 			}
 
-			fmt.Fprintf(
+			_, _ = fmt.Fprintf(
 				w,
 				// "Name: %s\n\tParent: %v (%v)\n\tState: %v\n\tPid: %v\n\tPPid: %v\n\tThreads: %v\n\n",
 				"  - Name: %10s [Parent: %v (%v), State: %v, Pid: %v, PPid: %v, Threads: %v]%s",
@@ -103,7 +103,7 @@ func writeReportProblemEntries(w io.Writer, processes process.Processes) {
 			)
 		}
 	default:
-		fmt.Fprintf(w, "%[1]s  - None%[1]s", nagios.CheckOutputEOL)
+		_, _ = fmt.Fprintf(w, "%[1]s  - None%[1]s", nagios.CheckOutputEOL)
 	}
 
 }
@@ -115,7 +115,7 @@ func CheckProcessReport(processes process.Processes) string {
 
 	writeReportHeader(&report, processes)
 
-	fmt.Fprintf(
+	_, _ = fmt.Fprintf(
 		&report,
 		"%[2]s%[1]s%[1]s",
 		nagios.CheckOutputEOL,


### PR DESCRIPTION
Resolve `return value of fmt.Fprintf is not checked`` errors by
explicitly discarding return values (potential error, bytes written)
since we do not need them and the potential for failure (in this
particular use case) is *highly* unlikely.
