### PR TITLE
Fix invalid Dependabot go.mod changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/atc0005/check-process
 
 go 1.23.0
 
-toolchain go1.24.1
-
 require (
 	github.com/atc0005/go-nagios v0.19.0
 	github.com/rs/zerolog v1.34.0


### PR DESCRIPTION
Remove Go toolchain directive incorrectly added by a recent Dependabot PR (regression).

Resolved by:

1. `go mod tidy`
2. `go mod edit -toolchain=none`

See also:

- https://github.com/dependabot/dependabot-core/issues/11825
- https://github.com/dependabot/dependabot-core/issues/11933